### PR TITLE
On restarting reset queued, submitting, retrying tasks to waiting...

### DIFF
--- a/bin/cylc-restart
+++ b/bin/cylc-restart
@@ -366,6 +366,11 @@ the remote host before starting the suite."""
             elif itask.state.is_currently(
                     'queued', 'retrying', 'submitting', 'failed'):  
                 itask.prerequisites.set_all_satisfied()
+                if not itask.state.is_currently( 'failed' ):
+                    # tasks that were queued, retrying, or submitting,
+                    # should be reset to waiting as they had not
+                    # actually been submitted yet.
+                    itask.state.set_status('waiting')
 
             elif itask.state.is_currently('succeeded'):  
                 itask.prerequisites.set_all_satisfied()


### PR DESCRIPTION
with prerequisites satisfied (because the pre-restart internal queues
are not reconstructed, and so on).
